### PR TITLE
i16: Using SLF4J API is not a standard, which is used in community version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ ext {
     mockitoVersion = '5.10.0'
     mongoDriverVersion = '5.0.0'
     mysqlVersion = '8.3.0'
+    natsClientVersion = '2.13.1'
     oracleVersion = '23.3.0.23.09'
     pahoMqttClientVersion = '1.2.5'
     postgresVersion = '42.7.3'
@@ -827,13 +828,14 @@ project('spring-integration-mqtt') {
 project('spring-integration-nats') {
     description = 'Spring Integration NATS Support'
     dependencies {
-        api 'io.nats:jnats:2.13.1'
-        api 'io.nats:nats-spring:0.5.0'
+        api "io.nats:jnats:$natsClientVersion"
         api 'com.fasterxml.jackson.core:jackson-databind'
 
-        testImplementation 'org.springframework.boot:spring-boot-starter:2.4.0'
+        //TODO: check reason for downgrading of testcontainers to 1.16.3 deviating from the version specified in $testcontainersVersion. Suggestion is nats-spring 0.5.0 defines dependencies to the specific version of spring-core.
+        testImplementation 'io.nats:nats-spring:0.5.0'
+        testImplementation 'org.testcontainers:testcontainers:1.16.3'
+        testImplementation 'javax.annotation:javax.annotation-api:1.3.2'
     }
-
 }
 
 project('spring-integration-redis') {


### PR DESCRIPTION
With this issue are removed as well following related issues: 

1. aligned versioning on community standard for src/main 
2. removed dependency nats-spring library from src/main 
3. found and realised versioning of nats-spring compatible with testcontainers. Defined TODO. 
4. removed dependency from spring-boot-starter(-test)
5. fixed finally [i20](https://github.com/rohlenko/spring-integration-nats/issues/20)



See more [i16](https://github.com/rohlenko/spring-integration-nats/issues/16)
<!--
Thanks for contributing to Spring Integration. 
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-integration/blob/main/CONTRIBUTING.adoc).
-->
